### PR TITLE
Add contract filtering

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -1,0 +1,8 @@
+const artblocks = {
+  "mainnet": {
+   "v1": "0x059edd72cd353df5106d2b9cc5ab83a52287ac3a",
+   "v2": "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270" 
+  }
+}
+
+export default { artblocks }

--- a/src/graph.js
+++ b/src/graph.js
@@ -1,27 +1,9 @@
 import fetch from 'node-fetch'
 
-// Most recent deployments of ArtBlocks on the graph
-const SUBGRAPH_MAINNET="https://api.thegraph.com/subgraphs/name/artblocks/art-blocks";
-const SUBGRAPH_ROPSTEN="https://api.thegraph.com/subgraphs/name/artblocks/art-blocks-artist-staging";
-
-function get_subgraph_api(network) {
-  switch (network) {
-    case "mainnet":
-      return SUBGRAPH_MAINNET
-    case "ropsten":
-      return SUBGRAPH_ROPSTEN
-    default:
-      throw new Error("Supported networks include 'mainnet' and 'ropsten'.")
-  }
-}
-
-async function artblocks_subgraph(query, network="mainnet") {
-  
-  // Check network
-  const url = get_subgraph_api(network)
+async function artblocks_subgraph(query, subgraph) {
 
   // Request variable query from the graph deployment
-  const response = await fetch(url, {
+  const response = await fetch(subgraph, {
     method: "post",
     headers: {
       "Content-Type": "application/json"

--- a/src/hashes.js
+++ b/src/hashes.js
@@ -7,8 +7,8 @@
 // V2 - { hash: hash_1, ...}
 //
 // This may change again with future contract versions
-function hash(project_id, token_id, token_hash) {
-  if (project_id < 3) {
+function hash(contract, token_id, token_hash) {
+  if (contract == "0x059edd72cd353df5106d2b9cc5ab83a52287ac3a") {
     return `let tokenData = {"hashes":["${token_hash}"], "tokenId":"${token_id}"}`
   } else {
     return `let tokenData = {"hash":"${token_hash}", "tokenId":"${token_id}"}`

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,27 @@
 import query from './query.js'
+import address from './address.js'
+
+// Most recent deployments of ArtBlocks on the graph
+const SUBGRAPH_MAINNET="https://api.thegraph.com/subgraphs/name/artblocks/art-blocks";
+const SUBGRAPH_ROPSTEN="https://api.thegraph.com/subgraphs/name/artblocks/art-blocks-artist-staging";
+
+function get_subgraph_api(network) {
+  switch (network) {
+    case "mainnet":
+      return SUBGRAPH_MAINNET
+    case "ropsten":
+      return SUBGRAPH_ROPSTEN
+    default:
+      throw new Error("Supported networks include 'mainnet' and 'ropsten'.")
+  }
+}
 
 class ArtBlocks {
   
-  constructor(api="thegraph", network="mainnet") {
+  constructor(api="thegraph", 
+              network="mainnet",
+              contracts=[], 
+              subgraph_custom="") {
 
     // TODO
     // Standardized interface for Infura and other data providers
@@ -10,41 +29,59 @@ class ArtBlocks {
     if (api != "thegraph") {
       throw new Error("Supported APIs include 'thegraph'.")
     }
-    if (!["mainnet", "ropsten"].includes(network)) {
-      throw new Error("Supported networks include 'mainnet' and 'ropsten'.")
+
+    // ArtBlocks (mainnet/ropsten) or custom subgraph endpoint
+    if (subgraph_custom != "") {
+      this.subgraph = subgraph_custom
+    } else {
+      if (!["mainnet", "ropsten"].includes(network)) {
+        throw new Error("Supported networks include 'mainnet' and 'ropsten'.")
+      }
+      this.subgraph = get_subgraph_api(network)
     }
+    
+    // Default contracts
+    if (contracts.length == 0) {
+      if (network == "mainnet") {
+        contracts = [address.artblocks.mainnet.v1, address.artblocks.mainnet.v2]
+      } else {
+        throw new Error("Must provide contracts for Ropsten projects.")
+      }
+    }
+
     this.api = api
     this.network = network
+    this.contracts = contracts
   }
 
   // Query all available projects
   projects() {
-    return query.projects(this.network)
+    return query.projects(this.subgraph, this.contracts)
   }
   
   // Query project metadata
   project_metadata(id) {
-    return query.project_metadata(id, this.network)
+    return query.project_metadata(id, this.subgraph, this.contracts)
   }
 
   // Query project raw script
   project_script(id) {
-    return query.project_script(id, this.network)
+    return query.project_script(id, this.subgraph, this.contracts)
   }
 
   // Query token metadata
   token_metadata(id) {
-    return query.token_metadata(id, this.network)
+    return query.token_metadata(id, this.subgraph, this.contracts)
   }
 
   // Query token raw script with hash and dependency tags
   token_script(id) {
-    return query.token_script(id, this.network)
+    return query.token_script(id, this.subgraph, this.contracts)
   }
 
   // Query token generator html file
   token_generator(id) {
-    return query.token_generator(id, this.network)
+    return query.token_generator(id, this.subgraph, this.contracts)
   }
 }
 


### PR DESCRIPTION
- Mainnet projects are now filtered by official ArtBlocks contracts by default
- Ropsten filtering now requires contracts from user
- Hashing methods are now determined by contract
- Allow for alternative subgraphs
- Slight refactoring